### PR TITLE
Add stage1 and stage2 pipeline scripts

### DIFF
--- a/stage1_extract_names.py
+++ b/stage1_extract_names.py
@@ -1,0 +1,36 @@
+import csv
+from modules.extraction import extract_item_name
+
+
+def main():
+    results = []
+    try:
+        with open("urls.csv", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                month = row.get("month", "")
+                url = row.get("url", "")
+                item_name = ""
+                error = ""
+                try:
+                    item_name = extract_item_name(url)
+                except Exception as e:
+                    error = str(e)
+                results.append({
+                    "month": month,
+                    "url": url,
+                    "item_name": item_name,
+                    "error": error,
+                })
+    except FileNotFoundError:
+        print("urls.csv not found")
+        return
+
+    with open("stage1_item_names.csv", "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["month", "url", "item_name", "error"])
+        writer.writeheader()
+        writer.writerows(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/stage2_resolve_brands.py
+++ b/stage2_resolve_brands.py
@@ -1,0 +1,41 @@
+import csv
+import json
+from modules.prompting import build_prompt
+from modules.model_client import prompt_model
+
+
+def main():
+    results = []
+    try:
+        with open("stage1_item_names.csv", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                url = row.get("url", "")
+                item_name = row.get("item_name", "").strip()
+                input_text = item_name if item_name else url
+                prompt = build_prompt(input_text)
+                brand = ""
+                brand_error = ""
+                try:
+                    raw = prompt_model(prompt)
+                    data = json.loads(raw)
+                    brand = data.get("name", "")
+                except Exception as e:
+                    brand_error = str(e)
+                results.append({
+                    "url": url,
+                    "brand": brand,
+                    "brand_error": brand_error,
+                })
+    except FileNotFoundError:
+        print("stage1_item_names.csv not found")
+        return
+
+    with open("final_brands.csv", "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["url", "brand", "brand_error"])
+        writer.writeheader()
+        writer.writerows(results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `stage1_extract_names.py` for item name scraping
- add `stage2_resolve_brands.py` for brand resolution

## Testing
- `python -m py_compile stage1_extract_names.py stage2_resolve_brands.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617e84cf308322ab109a84af929fea