### PR TITLE
Add parallel extraction with ThreadPoolExecutor

### DIFF
--- a/extract_names.py
+++ b/extract_names.py
@@ -1,36 +1,64 @@
 import csv
+import glob
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from modules.extraction import extract_item_name
 
+FIELDNAMES = ["month", "url", "item_count", "item_name", "error"]
+
+def process_row(row):
+    month = row.get("month", "")
+    url = row.get("item_url", "")
+    item_count = row.get("item_count", "")
+    item_name = ""
+    error = ""
+    print(f"Processing URL: {url}")
+    try:
+        item_name = extract_item_name(url)
+    except Exception as e:
+        error = str(e)
+
+    result = {
+        "month": month,
+        "url": url,
+        "item_count": item_count,
+        "item_name": item_name,
+        "error": error,
+    }
+
+    worker = threading.get_ident()
+    out_file = f"data/output/item_names_{worker}.csv"
+    is_new = not os.path.exists(out_file)
+    with open(out_file, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+        if is_new:
+            writer.writeheader()
+        writer.writerow(result)
+
+    return result
+
 def main():
-    results = []
     try:
         with open("data/input.csv", newline="") as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                month = row.get("month", "")
-                url = row.get("item_url", "")
-                item_count = row.get("item_count", "")
-                item_name = ""
-                error = ""
-                print(f"Processing URL: {url}")
-                try:
-                    item_name = extract_item_name(url)
-                except Exception as e:
-                    error = str(e)
-
-                results.append({
-                    "month": month,
-                    "url": url,
-                    "item_count": item_count,
-                    "item_name": item_name,
-                    "error": error,
-                })
+            rows = list(csv.DictReader(f))
     except FileNotFoundError:
         print("data/input.csv not found")
         return
 
+    with ThreadPoolExecutor(max_workers=os.cpu_count() or 1) as executor:
+        futures = [executor.submit(process_row, row) for row in rows]
+        for future in futures:
+            future.result()
+
+    results = []
+    for path in glob.glob("data/output/item_names_*.csv"):
+        with open(path, newline="") as f:
+            reader = csv.DictReader(f)
+            results.extend(reader)
+
     with open("data/output/item_names.csv", "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["month", "url", "item_count", "item_name", "error"])
+        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
         writer.writeheader()
         writer.writerows(results)
 


### PR DESCRIPTION
## Summary
- add multithreaded item name extraction using `ThreadPoolExecutor`
- move per-worker results to individual CSVs and merge them afterwards

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618ad39530832296d74034457d8d44