### PR TITLE
Add image_url extraction and persistence

### DIFF
--- a/extract_brands.py
+++ b/extract_brands.py
@@ -11,6 +11,7 @@ def process_row(row: dict) -> dict:
     month = row.get("month", "")
     url = row.get("url", "")
     item_count = row.get("item_count", "")
+    image_url = row.get("image_url", "")
 
     item_name = row.get("item_name", "").strip()
     input_text = item_name if item_name else url
@@ -30,6 +31,7 @@ def process_row(row: dict) -> dict:
         "month": month,
         "url": url,
         "item_count": item_count,
+        "image_url": image_url,
         "brand": brand,
         "brand_error": brand_error,
     }
@@ -37,7 +39,7 @@ def process_row(row: dict) -> dict:
 def worker(worker_id: int, rows: list[dict]):
     """Process a chunk of rows and write results to a worker specific file."""
     outfile = f"data/output/brands_{worker_id}.csv"
-    fieldnames = ["month", "url", "item_count", "brand", "brand_error"]
+    fieldnames = ["month", "url", "item_count", "image_url", "brand", "brand_error"]
     with open(outfile, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -62,7 +64,7 @@ def main():
         for future in futures:
             future.result()
 
-    fieldnames = ["month", "url", "item_count", "brand", "brand_error"]
+    fieldnames = ["month", "url", "item_count", "image_url", "brand", "brand_error"]
     with open("data/output/brands.csv", "w", newline="") as f_out:
         writer = csv.DictWriter(f_out, fieldnames=fieldnames)
         writer.writeheader()

--- a/extract_names.py
+++ b/extract_names.py
@@ -5,17 +5,18 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from modules.extraction import extract_item_name
 
-FIELDNAMES = ["month", "url", "item_count", "item_name", "error"]
+FIELDNAMES = ["month", "url", "item_count", "image_url", "item_name", "error"]
 
 def process_row(row):
     month = row.get("month", "")
     url = row.get("item_url", "")
     item_count = row.get("item_count", "")
     item_name = ""
+    image_url = ""
     error = ""
     print(f"Processing URL: {url}")
     try:
-        item_name = extract_item_name(url)
+        item_name, image_url = extract_item_name(url)
     except Exception as e:
         error = str(e)
 
@@ -23,6 +24,7 @@ def process_row(row):
         "month": month,
         "url": url,
         "item_count": item_count,
+        "image_url": image_url,
         "item_name": item_name,
         "error": error,
     }


### PR DESCRIPTION
## Summary
- support `image_url` in Firecrawl extraction
- include `image_url` column in `extract_names.py` output
- carry `image_url` through to `extract_brands.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68624bcef0e8832287b12fd333df08ee