### PR TITLE
Add image URL extraction and preserve in output CSVs

### DIFF
--- a/extract_brands.py
+++ b/extract_brands.py
@@ -12,6 +12,7 @@ def process_row(row: dict) -> dict:
     month = row.get("month", "")
     url = row.get("url", "")
     item_count = row.get("item_count", "")
+    image_url = row.get("image_url", "")
 
     item_name = row.get("item_name", "").strip()
     input_text = item_name if item_name else url
@@ -31,6 +32,7 @@ def process_row(row: dict) -> dict:
         "month": month,
         "url": url,
         "item_count": item_count,
+        "image_url": image_url,
         "brand": brand,
         "brand_error": brand_error,
     }
@@ -38,7 +40,7 @@ def process_row(row: dict) -> dict:
 def worker(worker_id: int, rows: list[dict]):
     """Process a chunk of rows and write results to a worker specific file."""
     outfile = f"data/output/brands_{worker_id}.csv"
-    fieldnames = ["month", "url", "item_count", "brand", "brand_error"]
+    fieldnames = ["month", "url", "item_count", "image_url", "brand", "brand_error"]
     with open(outfile, "a", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
@@ -73,7 +75,7 @@ def main():
         for future in futures:
             future.result()
 
-    fieldnames = ["month", "url", "item_count", "brand", "brand_error"]
+    fieldnames = ["month", "url", "item_count", "image_url", "brand", "brand_error"]
     with open("data/output/brands.csv", "a", newline="") as f_out:
         writer = csv.DictWriter(f_out, fieldnames=fieldnames)
         writer.writeheader()

--- a/extract_names.py
+++ b/extract_names.py
@@ -4,19 +4,20 @@ import os
 import threading
 import argparse
 from concurrent.futures import ThreadPoolExecutor
-from modules.extraction import extract_item_name
+from modules.extraction import extract_item_data
 
-FIELDNAMES = ["month", "url", "item_count", "item_name", "error"]
+FIELDNAMES = ["month", "url", "item_count", "image_url", "item_name", "error"]
 
 def process_row(row):
     month = row.get("month", "")
     url = row.get("item_url", "")
     item_count = row.get("item_count", "")
     item_name = ""
+    image_url = ""
     error = ""
     print(f"Processing URL: {url}")
     try:
-        item_name = extract_item_name(url)
+        item_name, image_url = extract_item_data(url)
     except Exception as e:
         error = str(e)
 
@@ -24,6 +25,7 @@ def process_row(row):
         "month": month,
         "url": url,
         "item_count": item_count,
+        "image_url": image_url,
         "item_name": item_name,
         "error": error,
     }


### PR DESCRIPTION
## Summary
- parse image URL from Firecrawl metadata
- return item name and image URL from extraction helpers
- include image URLs when extracting item names
- persist image URLs when determining brands

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68624cf583008322997aad5691384329