### PR TITLE
Fix rate limit retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Again, `--start` and `--end` let you select a subset of rows.
 ## Notes
 
 Both API helper functions include retry logic and will back off when a `429` rate limit
-response is received. They now retry up to **three** times by default. Adjust the
-`retries` parameter in `modules/extraction.py` and `modules/llm_client.py` if you need
-more attempts.
+response is received. They now retry up to **three** times by default.
+The Firecrawl helper extracts the suggested wait time from the error message when
+available before sleeping. Adjust the `retries` parameter in
+`modules/extraction.py` and `modules/llm_client.py` if you need more attempts.

--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ Again, `--start` and `--end` let you select a subset of rows.
 ## Notes
 
 Both API helper functions include retry logic and will back off when a `429` rate limit
-response is received. Adjust the `retries` parameter in `modules/extraction.py` and
-`modules/llm_client.py` if you need more attempts.
+response is received. They now retry up to **three** times by default. Adjust the
+`retries` parameter in `modules/extraction.py` and `modules/llm_client.py` if you need
+more attempts.

--- a/modules/extraction.py
+++ b/modules/extraction.py
@@ -29,7 +29,7 @@ def parse_image_url(meta: dict) -> str | None:
             return v
     return None
 
-def fetch_metadata(url: str, timeout: int = 30000, retries: int = 0) -> dict:
+def fetch_metadata(url: str, timeout: int = 30000, retries: int = 3) -> dict:
     """Call Firecrawl to fetch page metadata with retry and log how long it took."""
     last_error = None
     for attempt in range(retries + 1):

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -12,7 +12,7 @@ _client = OpenAI(
     default_query={"api-version": "preview"},
 )
 
-def prompt_model(prompt: str, timeout: int = 3, retries: int = 0) -> str:
+def prompt_model(prompt: str, timeout: int = 3, retries: int = 3) -> str:
     """Send a prompt to OpenAI with retry logic and report the request duration."""
     last_error = None
     for attempt in range(retries + 1):


### PR DESCRIPTION
## Summary
- default to three retries when calling Firecrawl and OpenAI APIs
- document the default retry behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686250838e608322aff1ede8fcfc5ff6