### PR TITLE
Handle Firecrawl metadata errors with retry

### DIFF
--- a/modules/extraction.py
+++ b/modules/extraction.py
@@ -43,7 +43,10 @@ def fetch_metadata(url: str, timeout: int = 20000, retries: int = 2) -> dict:
             )
             duration = time.perf_counter() - start
             print(f"Firecrawl request for {url} took {duration:.2f} seconds")
-            return resp.metadata
+            meta = resp.metadata
+            if "error" in meta:
+                raise RuntimeError(meta["error"])
+            return meta
         except Exception as e:
             last_error = e
             # Handle rate limit errors (HTTP 429)
@@ -60,8 +63,6 @@ def fetch_metadata(url: str, timeout: int = 20000, retries: int = 2) -> dict:
 def extract_item_data(url: str) -> tuple[str, str | None]:
     """Return item name and image URL for a given page."""
     meta = fetch_metadata(url)
-    if "error" in meta:
-        raise RuntimeError(f"Firecrawl API error: {meta["error"]}")
     name = parse_metadata(meta)
     if not name:
         raise ValueError("No valid item name found in metadata")

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -35,3 +35,20 @@ def test_prompt_model_attempts_once(monkeypatch):
     with pytest.raises(RuntimeError):
         llm_client.prompt_model("hi", retries=0)
     assert len(calls) == 1
+
+
+def test_fetch_metadata_retries_on_api_error(monkeypatch):
+    class Resp:
+        def __init__(self):
+            self.metadata = {"error": "bad"}
+
+    calls = []
+
+    def fake_scrape_url(*args, **kwargs):
+        calls.append(True)
+        return Resp()
+
+    monkeypatch.setattr(extraction.APP, "scrape_url", fake_scrape_url)
+    with pytest.raises(RuntimeError):
+        extraction.fetch_metadata("http://example.com", retries=2)
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary
- handle `Firecrawl` metadata errors directly in `fetch_metadata`
- retry when API returns an error in the metadata
- test that such errors trigger retries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686257484bcc8322ad004cf59bce999c