### PR TITLE
Handle Firecrawl retry hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ Again, `--start` and `--end` let you select a subset of rows.
 ## Notes
 
 Both API helper functions include retry logic and will back off when a `429` rate limit
-response is received. They now retry up to **three** times by default. Adjust the
-`retries` parameter in `modules/extraction.py` and `modules/llm_client.py` if you need
-more attempts.
+response is received. The metadata extraction helper now retries up to **two** times by
+default. Adjust the `retries` parameter in `modules/extraction.py` and
+`modules/llm_client.py` if you need more attempts.

--- a/modules/extraction.py
+++ b/modules/extraction.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+import re
 from dotenv import load_dotenv
 from firecrawl import FirecrawlApp
 import requests
@@ -51,7 +52,11 @@ def fetch_metadata(url: str, timeout: int = 20000, retries: int = 2) -> dict:
             last_error = e
             # Handle rate limit errors (HTTP 429)
             if isinstance(e, requests.exceptions.HTTPError) and getattr(e.response, "status_code", None) == 429:
-                wait = min(2 ** attempt, 60)
+                match = re.search(r"retry after (\d+)s", str(e), re.I)
+                if match:
+                    wait = int(match.group(1))
+                else:
+                    wait = min(2 ** attempt, 60)
                 print(f"Firecrawl rate limit hit. Sleeping for {wait} seconds")
                 time.sleep(wait)
             if attempt < retries:


### PR DESCRIPTION
## Summary
- parse wait time from Firecrawl error messages
- update README to reflect new default retries
- adjust tests for default retry count and add coverage for retry message parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625c46ff9c83229ecf98109e0728c2