### PR TITLE
Implement thread-safe rate limiting

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pytest
+import requests
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("FIRECRAWL_API_KEY", "test")
+
+import modules.extraction as extraction
+
+
+def test_fetch_metadata_waits_for_next_allowed_time(monkeypatch):
+    extraction.NEXT_ALLOWED_TIME = 0.0
+    calls = []
+
+    class Resp:
+        metadata = {}
+
+    def fake_scrape_url(*args, **kwargs):
+        if not calls:
+            calls.append("first")
+            resp = type("R", (), {"status_code": 429})()
+            raise requests.exceptions.HTTPError(response=resp)
+        calls.append("second")
+        return Resp()
+
+    monkeypatch.setattr(extraction.APP, "scrape_url", fake_scrape_url)
+
+    sleep_calls = []
+    monkeypatch.setattr(extraction.time, "sleep", lambda s: sleep_calls.append(s))
+
+    with pytest.raises(RuntimeError):
+        extraction.fetch_metadata("http://example.com", retries=0)
+
+    extraction.fetch_metadata("http://example.com", retries=0)
+
+    assert sleep_calls[-1] == pytest.approx(1.0, abs=0.01)


### PR DESCRIPTION
## Summary
- add global lock and next allowed time to `modules/extraction`
- enforce rate limiting in `fetch_metadata`
- test waiting behaviour when a 429 is encountered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625c5333c483229a5bf6b2f6bc8321