### PR TITLE
Add thread pool helpers and refactor scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,25 @@ pip install -r requirements.txt
 
 1. **Extract item names**
 
-```bash
-python extract_names.py --start 1 --end 100
+```python
+import csv, extract_names
+
+rows = list(csv.DictReader(open("data/input.csv")))
+extract_names.batch_process(rows, max_workers=2)
 ```
 
 This reads `data/input.csv`, fetches metadata with Firecrawl and writes the results to `data/output/item_names.csv`.
-Use `--start` and `--end` to limit which rows are processed (both inclusive).
 
 2. **Extract brand names**
 
-```bash
-python extract_brands.py --start 1 --end 100
+```python
+import csv, extract_brands
+
+rows = list(csv.DictReader(open("data/output/item_names.csv")))
+extract_brands.batch_process(rows)
 ```
 
 This reads the item names file produced above and writes `data/output/brands.csv`.
-Again, `--start` and `--end` let you select a subset of rows.
 
 ## Notes
 

--- a/extract_names.py
+++ b/extract_names.py
@@ -1,45 +1,12 @@
 import csv
-import glob
-import os
-import threading
 import argparse
-from concurrent.futures import ThreadPoolExecutor
-from modules.extraction import extract_item_data
+from modules.extraction import batch_extract
 
 FIELDNAMES = ["month", "url", "item_count", "image_url", "item_name", "error"]
 
-def process_row(row):
-    month = row.get("month", "")
-    url = row.get("item_url", "")
-    item_count = row.get("item_count", "")
-    item_name = ""
-    image_url = ""
-    error = ""
-    print(f"Processing URL: {url}")
-    try:
-        item_name, image_url = extract_item_data(url)
-    except Exception as e:
-        error = str(e)
-
-    result = {
-        "month": month,
-        "url": url,
-        "item_count": item_count,
-        "image_url": image_url,
-        "item_name": item_name,
-        "error": error,
-    }
-
-    worker = threading.get_ident()
-    out_file = f"data/output/item_names_{worker}.csv"
-    is_new = not os.path.exists(out_file)
-    with open(out_file, "a", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
-        if is_new:
-            writer.writeheader()
-        writer.writerow(result)
-
-    return result
+def batch_process(rows, max_workers: int = 2):
+    """Return processed rows with extracted item names."""
+    return batch_extract(rows, max_workers=max_workers)
 
 def main():
     parser = argparse.ArgumentParser(description="Extract item names from URLs")
@@ -59,21 +26,7 @@ def main():
     rows = all_rows[start:end]
     print(f"Processing rows {start + 1} to {min(end, len(all_rows))} of {len(all_rows)}")
 
-    max_workers = 2 # limited to 2 concurrent due to Firecrawl API free plan rate limit
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [executor.submit(process_row, row) for row in rows]
-        for future in futures:
-            future.result()
-
-    results = []
-    for path in glob.glob("data/output/item_names_*.csv"):
-        with open(path, newline="") as f:
-            reader = csv.DictReader(f)
-            results.extend(reader)
-        try:
-            os.remove(path)
-        except OSError as e:
-            print(f"Error deleting {path}: {e}")
+    results = batch_process(rows, max_workers=2)
 
     with open("data/output/item_names.csv", "a", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=FIELDNAMES)


### PR DESCRIPTION
## Summary
- add `_thread_map` and `batch_extract` helpers in extraction module
- refactor scripts to use new helpers
- update README examples for new entry points

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625c5a3574832281a6c9bc8daafaa0