### PR TITLE
Strip query parameters from image URLs

### DIFF
--- a/modules/extraction.py
+++ b/modules/extraction.py
@@ -29,11 +29,11 @@ def parse_metadata(meta: dict) -> str:
 
 
 def parse_image_url(meta: dict) -> str | None:
-    """Return an image URL from metadata if available."""
+    """Return an image URL from metadata if available without query parameters."""
     for key in ["og:image", "ogImage", "twitter:image:src", "image"]:
         v = meta.get(key)
         if isinstance(v, str) and v.strip():
-            return v
+            return v.split("?", 1)[0]
     return None
 
 

--- a/tests/test_parse_image_url.py
+++ b/tests/test_parse_image_url.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("FIRECRAWL_API_KEY", "test")
+
+from modules.extraction import parse_image_url
+
+
+def test_parse_image_url_strips_query_string():
+    meta = {"og:image": "https://example.com/img.jpg?width=100&height=100"}
+    assert parse_image_url(meta) == "https://example.com/img.jpg"
+


### PR DESCRIPTION
## Summary
- remove query strings in `parse_image_url`
- add regression test for `parse_image_url`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f0f7cad88322a548b50ad1dcb2d9