### PR TITLE
Add fallback item name support

### DIFF
--- a/extract_brands.py
+++ b/extract_brands.py
@@ -21,6 +21,7 @@ def process_row(row: dict) -> dict:
             "month": month,
             "url": url,
             "item_count": item_count,
+            "item_name": item_name,
             "image_url": image_url,
             "brand": "",
             "brand_error": error,
@@ -43,6 +44,7 @@ def process_row(row: dict) -> dict:
         "month": month,
         "url": url,
         "item_count": item_count,
+        "item_name": item_name,
         "image_url": image_url,
         "brand": brand,
         "brand_error": brand_error,
@@ -75,7 +77,15 @@ def main():
 
     results = batch_process(rows)
 
-    fieldnames = ["month", "url", "item_count", "image_url", "brand", "brand_error"]
+    fieldnames = [
+        "month",
+        "url",
+        "item_count",
+        "item_name",
+        "image_url",
+        "brand",
+        "brand_error",
+    ]
     with open("data/output/brands.csv", "a", newline="") as f_out:
         writer = csv.DictWriter(f_out, fieldnames=fieldnames)
         writer.writeheader()

--- a/extract_names.py
+++ b/extract_names.py
@@ -2,7 +2,15 @@ import csv
 import argparse
 from modules.extraction import batch_extract
 
-FIELDNAMES = ["month", "url", "item_count", "image_url", "item_name", "error"]
+FIELDNAMES = [
+    "month",
+    "url",
+    "item_count",
+    "image_url",
+    "item_name",
+    "error",
+    "used_fallback",
+]
 
 def batch_process(rows, max_workers: int = 2):
     """Return processed rows with extracted item names."""

--- a/modules/extraction.py
+++ b/modules/extraction.py
@@ -124,14 +124,18 @@ def batch_extract(rows: list[dict], max_workers: int = 2) -> list[dict]:
         month = row.get("month", "")
         url = row.get("item_url") or row.get("url", "")
         item_count = row.get("item_count", "")
+        original_item_name = row.get("item_name", "")
         item_name = ""
         image_url = ""
         error = ""
+        used_fallback = False
         print(f"Processing URL: {url}")
         try:
             item_name, image_url = extract_item_data(url)
         except Exception as e:  # noqa: BLE001
             error = str(e)
+            item_name = original_item_name
+            used_fallback = bool(item_name)
 
         return {
             "month": month,
@@ -140,6 +144,7 @@ def batch_extract(rows: list[dict], max_workers: int = 2) -> list[dict]:
             "image_url": image_url,
             "item_name": item_name,
             "error": error,
+            "used_fallback": used_fallback,
         }
 
     return _thread_map(_worker, rows, max_workers)

--- a/tests/test_access_denied.py
+++ b/tests/test_access_denied.py
@@ -30,6 +30,7 @@ def test_access_denied_error_propagates(monkeypatch):
     item_row = results[0]
     assert item_row["item_name"] == ""
     assert item_row["error"] == "Access Denied"
+    assert item_row["used_fallback"] is False
 
     def fail_prompt(*args, **kwargs):  # pragma: no cover - should not be called
         raise AssertionError("prompt_model should not be called")
@@ -38,5 +39,6 @@ def test_access_denied_error_propagates(monkeypatch):
 
     brand_row = eb.process_row(item_row)
 
+    assert brand_row["item_name"] == ""
     assert brand_row["brand"] == ""
     assert brand_row["brand_error"] == "Access Denied"

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("FIRECRAWL_API_KEY", "test")
+
+import modules.extraction as extraction
+
+
+def test_fallback_item_name_used(monkeypatch):
+    row = {
+        "month": "2025-06-01",
+        "url": "http://example.com",
+        "item_count": "1",
+        "item_name": "Fallback Name",
+    }
+
+    def fail_extract(*args, **kwargs):
+        raise Exception("fail")
+
+    monkeypatch.setattr(extraction, "extract_item_data", fail_extract)
+
+    results = extraction.batch_extract([row], max_workers=1)
+    item_row = results[0]
+
+    assert item_row["item_name"] == "Fallback Name"
+    assert item_row["error"] == "fail"
+    assert item_row["used_fallback"] is True
+


### PR DESCRIPTION
## Summary
- track when the item name falls back to the input value
- include item_name when extracting brand data
- persist fallback flag in output
- test new fallback behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f466e7b48322bb0ab5e8d80e631f