### PR TITLE
Add brand name cleanup

### DIFF
--- a/extract_brands.py
+++ b/extract_brands.py
@@ -7,6 +7,15 @@ from modules.llm_client import prompt_model
 from modules.extraction import _thread_map
 
 
+def cleanup_brand_name(name: str) -> str:
+    """Return a cleaned brand name for easier consolidation."""
+    if not name:
+        return ""
+    cleaned = name.replace("_", " ").replace("-", " ")
+    cleaned = " ".join(cleaned.split())
+    return cleaned.title()
+
+
 def process_row(row: dict) -> dict:
     """Process a single CSV row and return the brand extraction result."""
     month = row.get("month", "")
@@ -36,7 +45,7 @@ def process_row(row: dict) -> dict:
     try:
         raw = prompt_model(prompt)
         data = json.loads(raw)
-        brand = data.get("name", "")
+        brand = cleanup_brand_name(data.get("name", ""))
     except Exception as e:
         brand_error = str(e)
 

--- a/tests/test_brand_cleanup.py
+++ b/tests/test_brand_cleanup.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("FIRECRAWL_API_KEY", "test")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "test")
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://example.com/")
+os.environ.setdefault("AZURE_OPENAI_DEPLOYMENT", "test")
+
+import extract_brands as eb
+
+
+def test_brand_name_cleanup(monkeypatch):
+    row = {
+        "month": "2025-07-01",
+        "url": "http://example.com",
+        "item_count": "1",
+        "item_name": "Some Item",
+        "image_url": "",
+    }
+
+    monkeypatch.setattr(eb, "prompt_model", lambda *a, **k: json.dumps({"name": "mega-brand_name"}))
+
+    result = eb.process_row(row)
+    assert result["brand"] == "Mega Brand Name"


### PR DESCRIPTION
## Summary
- add `cleanup_brand_name` helper to normalize brand names
- apply cleaning step after calling the LLM
- test that brand cleanup works correctly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f85317bc8322b4291ba3b75159d0